### PR TITLE
Fix hiding a single tab

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,12 +23,12 @@ exports.decorateBrowserOptions = defaults => Object.assign({}, defaults, {
 })
 
 exports.getTabsProps = (parentProps, props) => {
-  const bodyClasses = document.body.classList
+  const hyper = document.querySelector('.hyper_main')
 
   if (props.tabs.length <= 1) {
-    bodyClasses.add('closed-tabs')
+    hyper.classList.add('closed-tabs')
   } else {
-    bodyClasses.remove('closed-tabs')
+    hyper.classList.remove('closed-tabs')
   }
 
   return Object.assign({}, parentProps, props)

--- a/styles.css
+++ b/styles.css
@@ -21,7 +21,7 @@
   height: calc(100% - 23px);
 }
 
-body.closed-tabs .terms_terms {
+.closed-tabs .terms_terms {
   height: 100%;
 }
 
@@ -32,7 +32,7 @@ body.closed-tabs .terms_terms {
   border-bottom: 1px solid #B2B2B2;
 }
 
-body.closed-tabs .tabs_nav {
+.closed-tabs .tabs_nav {
   display: none;
 }
 


### PR DESCRIPTION
This targets an element that is inside the scope of the `#hyper` element and so the styling is applied when appropriate 👌 